### PR TITLE
feat: make able to build their own custom engine

### DIFF
--- a/api/src/constructor.ts
+++ b/api/src/constructor.ts
@@ -1,13 +1,17 @@
 import { Proxmox } from "./model";
 import ProxmoxEngine from "./ProxmoxEngine";
-import { buildApiProxy } from "./proxy";
+import { ApiRequestable, buildApiProxy } from "./proxy";
 import { ProxmoxEngineOptions } from './ProxmoxEngine';
 
-export function proxmoxApi(options: ProxmoxEngineOptions | ProxmoxEngine): Proxmox.Api {
-    if ((options as any).getTicket)
-        return buildApiProxy(options as ProxmoxEngine, '/api2/json');
+function isProxmoxEngine(val: any): val is ApiRequestable {
+    return 'doRequest' in val;
+}
+
+export function proxmoxApi(options: ProxmoxEngineOptions | ApiRequestable): Proxmox.Api {
+    if (isProxmoxEngine(options))
+        return buildApiProxy(options, '/api2/json');
     else
-        return buildApiProxy(new ProxmoxEngine(options as ProxmoxEngineOptions), '/api2/json');
+        return buildApiProxy(new ProxmoxEngine(options), '/api2/json');
 }
 
 export default proxmoxApi;

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,11 +1,9 @@
-import { proxmoxApi } from './constructor';
-export { proxmoxApi } from './constructor';
-export { Proxmox } from './model';
-export { USBHostInfo, USBInfo, QmMonitor } from './QmMonitor'
-export { ProxmoxEngineOptions, ProxmoxEngineOptionsCommon, ProxmoxEngineOptionsPass, ProxmoxEngineOptionsToken } from './ProxmoxEngine';
+export * from './constructor';
+export { proxmoxApi as default } from './constructor';
+export * from './model';
+export * from './QmMonitor'
+export * from './ProxmoxEngine';
 
 // for stress test
-// export { buildApiProxy } from './proxy';
-export { ProxmoxEngine } from './ProxmoxEngine'
-
-export default proxmoxApi;
+export * from './proxy';
+export * from './ProxmoxEngine'

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,9 +1,8 @@
-export * from './constructor';
+export { proxmoxApi } from './constructor';
 export { proxmoxApi as default } from './constructor';
-export * from './model';
-export * from './QmMonitor'
-export * from './ProxmoxEngine';
+export { Proxmox } from './model';
+export { USBHostInfo, USBInfo, QmMonitor } from './QmMonitor'
+export { ProxmoxEngineOptions, ProxmoxEngineOptionsCommon, ProxmoxEngineOptionsPass, ProxmoxEngineOptionsToken, ProxmoxEngine } from './ProxmoxEngine';
 
 // for stress test
-export * from './proxy';
-export * from './ProxmoxEngine'
+export { ApiRequestable } from './proxy';


### PR DESCRIPTION
This change is so people can create their own custom engine by implementing `ApiRequestable`.

I recommendation to export all type definitions so that the type can be reused in own code.
Also I change `ProxmoxEngine` to `ApiRequestable` in function `proxmoxApi`, because basically `ProxmoxEngine` is implementation of `ApiRequestable`.