### PR TITLE
Optional Port

### DIFF
--- a/api/src/ProxmoxEngine.ts
+++ b/api/src/ProxmoxEngine.ts
@@ -162,7 +162,17 @@ export class ProxmoxEngine implements ApiRequestable {
         }
         // parameters
         let body: any | undefined = undefined;
-        const requestUrl = new URL(`${this.schema}://${this.host}:${this.port}${path}`);
+
+        // proxmox base url
+        let requestUrl: URL;
+
+        if(this.port) {
+         requestUrl = new URL(`${this.schema}://${this.host}:${this.port}${path}`);
+        } else {
+         requestUrl = new URL(`${this.schema}://${this.host}${path}`);
+        }
+
+
         if (typeof (params) === 'object' && Object.keys(params).length > 0) {
             let searchParams: URLSearchParams;
             if (method === 'PUT' || method === 'POST') {

--- a/api/src/ProxmoxEngine.ts
+++ b/api/src/ProxmoxEngine.ts
@@ -89,7 +89,7 @@ export class ProxmoxEngine implements ApiRequestable {
     private readonly username: string;
     private readonly password: string;
     private host: string;
-    private port: number;
+    private port?: number;
     private readonly schema: 'http' | 'https';
     private authTimeout: number;
     private queryTimeout: number;

--- a/api/src/ProxmoxEngine.ts
+++ b/api/src/ProxmoxEngine.ts
@@ -298,7 +298,16 @@ export class ProxmoxEngine implements ApiRequestable {
             if (this.CSRFPreventionToken)
                 return { ticket: this.ticket, CSRFPreventionToken: this.CSRFPreventionToken };
         }
-        const requestUrl = `${this.schema}://${this.host}:${this.port}/api2/json/access/ticket`;
+
+        // update ticket endpoint
+        let requestUrl: string;
+
+        if(this.port) {
+            requestUrl = `${this.schema}://${this.host}:${this.port}/api2/json/access/ticket`;
+        } else {
+            requestUrl = `${this.schema}://${this.host}/api2/json/access/ticket`;
+        }
+
         try {
             const { password, username } = this;
             const body = new URLSearchParams({ username, password }).toString();

--- a/api/src/ProxmoxEngine.ts
+++ b/api/src/ProxmoxEngine.ts
@@ -125,7 +125,7 @@ export class ProxmoxEngine implements ApiRequestable {
             }
         }
         this.host = options.host;
-        this.port = options.port || 8006;
+        this.port = options.port;
         this.schema = options.schema || 'https';
         this.authTimeout = options.authTimeout || 5000;
         this.queryTimeout = options.queryTimeout || 60000;


### PR DESCRIPTION
Useful if proxmox is behind a proxy that masks the port, or is behind a tunnel like Cloudflare ZeroTrust tunnel, support for custom ports in such a case is limited and only standard HTTP ports(80, 443) are allowed.

The PORT can be safely omitted and the API will fallback to standard HTTP ports guided by the URL Protocol.